### PR TITLE
add full rating names

### DIFF
--- a/lib/post/data/post.dart
+++ b/lib/post/data/post.dart
@@ -424,7 +424,7 @@ class Flags {
 
 enum Rating { E, S, Q }
 
-final ratingValues = EnumValues({"e": Rating.E, "q": Rating.Q, "s": Rating.S});
+final ratingValues = EnumValues({"e": Rating.E, "q": Rating.Q, "s": Rating.S, "explicit": Rating.E, "questionable": Rating.Q, "safe": Rating.S});
 
 class Relationships {
   Relationships({


### PR DESCRIPTION
Currently the app only checks if there is the rating initial, i.e if you had "rating:e" in your blacklist, it'd work but "rating:explicit" wouldn't.

I hope to fix it. I do not have access to test this, but I hope it works like this 😅 