### PR TITLE
Change fave icon color when favorited

### DIFF
--- a/lib/post/widgets/detail/widgets/likes.dart
+++ b/lib/post/widgets/detail/widgets/likes.dart
@@ -64,9 +64,12 @@ class LikeDisplay extends StatelessWidget {
             Row(
               children: [
                 Text(post.favCount.toString()),
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 8),
-                  child: Icon(Icons.favorite),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Icon(
+                    Icons.favorite,
+                    color: post.isFavorited ? Colors.pinkAccent : IconTheme.of(context).color,
+                  ),
                 ),
               ],
             ),


### PR DESCRIPTION
Sometimes when browsing I noticed that my eyes naturally drift to the favorite count icon on a post and see it white even if its favorited. It seems like it would be helpful for myself and maybe others to also tint that favorite icon pink if the post is favorited. 