### PR TITLE
Use 'director' tags as artist display if 'artist' tags not found.

### DIFF
--- a/lib/post/data/download.dart
+++ b/lib/post/data/download.dart
@@ -106,7 +106,7 @@ extension PostDownloading on Post {
 
   String _downloadName() {
     String filename = '';
-    List<String> artists = filterArtists(tags['artist'] ?? []);
+    List<String> artists = filterArtists(tags['artist'] ?? tags['director'] ?? []);
     if (artists.isNotEmpty) {
       filename = '${artists.join(', ')} - ';
     }

--- a/lib/post/widgets/detail/widgets/artist.dart
+++ b/lib/post/widgets/detail/widgets/artist.dart
@@ -84,7 +84,7 @@ class ArtistName extends StatelessWidget {
         context.select<PostEditingController?, Map<String, List<String>>>(
             (value) => value?.value?.tags ?? post.tags);
 
-    List<String> artists = filterArtists((tags)['artist'] ?? []);
+    List<String> artists = filterArtists((tags)['artist'] ?? (tags)['director'] ?? []);
     if (artists.isNotEmpty) {
       return OverflowBar(
         children: [


### PR DESCRIPTION
In e6ai.net, there are only Directors and not Artists. In the current version, if users view post details or download pictures, the information will not be displayed.

Since the director label category does not exist on other sites, it can be considered that it has no impact on other sites.