### PR TITLE
port database clients and repos

### DIFF
--- a/lib/app/data/data.dart
+++ b/lib/app/data/data.dart
@@ -1,2 +1,4 @@
 export 'capabilities.dart';
 export 'init.dart';
+export 'storage.dart';
+export 'storage.drift.dart';

--- a/lib/app/data/init.dart
+++ b/lib/app/data/init.dart
@@ -1,7 +1,65 @@
-import 'package:e1547/settings/settings.dart';
+import 'dart:io';
 
-typedef AppInitBundle = ({SettingsService settings});
+import 'package:drift_flutter/drift_flutter.dart';
+import 'package:e1547/app/data/storage.dart';
+import 'package:e1547/settings/settings.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:http_cache_drift_store/http_cache_drift_store.dart';
+import 'package:notified_preferences/notified_preferences.dart';
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+
+typedef AppInitBundle = ({SettingsService settings, AppStorage storage});
 
 Future<AppInitBundle> initApp() async {
-  return (settings: await SettingsService.init(),);
+  final settings = await SettingsService.init();
+  final storage = await initializeAppStorage();
+  return (settings: settings, storage: storage);
+}
+
+Future<AppStorage> initializeAppStorage({bool cache = true}) async {
+  final String temporaryFiles = await getTemporaryAppDirectory();
+  await cleanupImageCache();
+  return AppStorage(
+    preferences: await SharedPreferences.getInstance(),
+    temporaryFiles: temporaryFiles,
+    httpCache: cache ? DriftCacheStore(databasePath: temporaryFiles) : null,
+    sqlite: AppDatabase(
+      driftDatabase(
+        name: 'app',
+        native: DriftNativeOptions(
+          shareAcrossIsolates: true,
+          databasePath: () => getApplicationSupportDirectory().then(
+            (dir) => join(dir.path, 'app.db'),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<String> getTemporaryAppDirectory() =>
+    getTemporaryDirectory().then((dir) => join(dir.path, 'e1547'));
+
+Future<void> cleanupImageCache({
+  Duration stalePeriod = const Duration(days: 1),
+}) async {
+  final base = await getTemporaryDirectory();
+  final cacheDir = Directory(join(base.path, DefaultCacheManager.key));
+  if (!cacheDir.existsSync()) return;
+
+  final staleBefore = DateTime.now().subtract(stalePeriod);
+
+  await for (final entity in cacheDir.list()) {
+    if (entity is! File) continue;
+
+    try {
+      final stat = entity.statSync();
+      if (stat.modified.isBefore(staleBefore)) {
+        await entity.delete();
+      }
+    } on FileSystemException {
+      // ignore
+    }
+  }
 }

--- a/lib/app/data/storage.dart
+++ b/lib/app/data/storage.dart
@@ -1,0 +1,42 @@
+import 'package:drift/drift.dart';
+import 'package:e1547/identity/data/client.dart';
+import 'package:e1547/traits/traits.dart';
+import 'package:http_cache_drift_store/http_cache_drift_store.dart';
+import 'package:notified_preferences/notified_preferences.dart';
+
+// ignore: always_use_package_imports
+import 'storage.drift.dart';
+
+@DriftDatabase(tables: [IdentitiesTable, TraitsTable])
+class AppDatabase extends $AppDatabase {
+  AppDatabase(super.e);
+
+  @override
+  int get schemaVersion => 1;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onCreate: (m) => m.createAll(),
+    beforeOpen: (details) => customStatement('PRAGMA foreign_keys = ON'),
+  );
+}
+
+/// Holds various databases for the app.
+class AppStorage {
+  const AppStorage({
+    required this.preferences,
+    required this.temporaryFiles,
+    required this.httpCache,
+    required this.sqlite,
+  });
+
+  final SharedPreferences preferences;
+  final String temporaryFiles;
+  final DriftCacheStore? httpCache;
+  final AppDatabase sqlite;
+
+  Future<void> close() async {
+    await httpCache?.close();
+    await sqlite.close();
+  }
+}

--- a/lib/app/data/storage.drift.dart
+++ b/lib/app/data/storage.drift.dart
@@ -1,0 +1,48 @@
+// dart format width=80
+// ignore_for_file: type=lint
+import 'package:drift/drift.dart' as i0;
+import 'package:e1547/identity/data/client.drift.dart' as i1;
+import 'package:e1547/traits/data/client.drift.dart' as i2;
+
+abstract class $AppDatabase extends i0.GeneratedDatabase {
+  $AppDatabase(i0.QueryExecutor e) : super(e);
+  $AppDatabaseManager get managers => $AppDatabaseManager(this);
+  late final i1.$IdentitiesTableTable identitiesTable = i1
+      .$IdentitiesTableTable(this);
+  late final i2.$TraitsTableTable traitsTable = i2.$TraitsTableTable(this);
+  @override
+  Iterable<i0.TableInfo<i0.Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<i0.TableInfo<i0.Table, Object?>>();
+  @override
+  List<i0.DatabaseSchemaEntity> get allSchemaEntities => [
+    identitiesTable,
+    traitsTable,
+  ];
+  @override
+  i0.StreamQueryUpdateRules get streamUpdateRules =>
+      const i0.StreamQueryUpdateRules([
+        i0.WritePropagation(
+          on: i0.TableUpdateQuery.onTableName(
+            'identities_table',
+            limitUpdateKind: i0.UpdateKind.delete,
+          ),
+          result: [i0.TableUpdate('traits_table', kind: i0.UpdateKind.delete)],
+        ),
+        i0.WritePropagation(
+          on: i0.TableUpdateQuery.onTableName(
+            'identities_table',
+            limitUpdateKind: i0.UpdateKind.update,
+          ),
+          result: [i0.TableUpdate('traits_table', kind: i0.UpdateKind.update)],
+        ),
+      ]);
+}
+
+class $AppDatabaseManager {
+  final $AppDatabase _db;
+  $AppDatabaseManager(this._db);
+  i1.$$IdentitiesTableTableTableManager get identitiesTable =>
+      i1.$$IdentitiesTableTableTableManager(_db, _db.identitiesTable);
+  i2.$$TraitsTableTableTableManager get traitsTable =>
+      i2.$$TraitsTableTableTableManager(_db, _db.traitsTable);
+}

--- a/lib/identity/data/actions.dart
+++ b/lib/identity/data/actions.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+import 'package:e1547/identity/identity.dart';
+
+String encodeBasicAuth(String username, String password) =>
+    'Basic ${base64Encode(utf8.encode('$username:$password'))}';
+
+(String username, String password)? parseBasicAuth(String? auth) {
+  if (auth == null) return null;
+  RegExpMatch? fullBasicMatch = RegExp(
+    r'Basic (?<encoded>[A-Za-z\d/=]+)',
+  ).firstMatch(auth);
+  if (fullBasicMatch == null) return null;
+  RegExpMatch? credentialMatch = RegExp(r'(?<username>.+):(?<password>.+)')
+      .firstMatch(
+        utf8.decode(base64Decode(fullBasicMatch.namedGroup('encoded')!)),
+      );
+  if (credentialMatch == null) return null;
+  return (
+    credentialMatch.namedGroup('username')!,
+    credentialMatch.namedGroup('password')!,
+  );
+}
+
+/// Returns a new URL which is guaranteed to
+/// - have a scheme (defaults to https)
+/// - not have a trailing slash
+/// - not contain a query or fragment
+String normalizeHostUrl(String url) {
+  Uri uri = Uri.parse(url);
+  if (uri.host.isEmpty && uri.path.isNotEmpty) {
+    uri = Uri.https(uri.path);
+  }
+  if (uri.path.endsWith('/')) {
+    uri = uri.replace(path: uri.path.substring(0, uri.path.length - 1));
+  }
+  if (uri.scheme.isEmpty) {
+    uri = uri.replace(scheme: 'https');
+  }
+  uri = Uri(
+    scheme: uri.scheme,
+    userInfo: uri.userInfo,
+    host: uri.host,
+    port: uri.port,
+    path: uri.path,
+  );
+  return uri.toString();
+}
+
+String assembleHostedUrl(String host, String path) {
+  Uri uri = Uri.parse(normalizeHostUrl(host));
+  Uri other = Uri.parse(path);
+
+  path = other.path;
+  if (!path.startsWith('/')) path = '/$path';
+  path = '${uri.path}$path';
+
+  Map<String, dynamic>? queryParameters = other.queryParameters;
+  if (queryParameters.isEmpty) queryParameters = null;
+
+  String? fragment = other.fragment;
+  if (fragment.isEmpty) fragment = null;
+
+  return uri
+      .replace(path: path, queryParameters: queryParameters, fragment: fragment)
+      .toString();
+}
+
+extension HostedUrlsExtenstion on Identity {
+  String withHost(String path) => assembleHostedUrl(host, path);
+}
+
+extension IdentityUsernaming on Identity {
+  String get usernameOrAnon => username ?? 'Anonymous';
+}

--- a/lib/identity/data/client.dart
+++ b/lib/identity/data/client.dart
@@ -1,0 +1,137 @@
+import 'dart:math';
+
+import 'package:drift/drift.dart';
+import 'package:e1547/identity/data/actions.dart';
+import 'package:e1547/identity/data/client.drift.dart';
+import 'package:e1547/identity/data/identity.dart';
+import 'package:e1547/shared/shared.dart';
+import 'package:e1547/stream/stream.dart';
+
+class NullToEmptyStringSqlConverter extends TypeConverter<String?, String> {
+  const NullToEmptyStringSqlConverter();
+
+  @override
+  String? fromSql(String fromDb) => fromDb.isEmpty ? null : fromDb;
+
+  @override
+  String toSql(String? value) => value ?? '';
+}
+
+@UseRowClass(Identity, generateInsertable: true)
+class IdentitiesTable extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get host => text()();
+  TextColumn get username =>
+      text().map(const NullToEmptyStringSqlConverter())();
+  TextColumn get headers =>
+      text().nullable().map(JsonSqlConverter.map<String>())();
+
+  @override
+  List<Set<Column<Object>>>? get uniqueKeys => [
+    {host, username},
+  ];
+}
+
+@DriftAccessor(tables: [IdentitiesTable])
+class IdentityClient extends DatabaseAccessor<GeneratedDatabase>
+    with $IdentityClientMixin {
+  IdentityClient(super.db);
+
+  StreamFuture<int> length() {
+    final Expression<int> count = identitiesTable.id.count();
+
+    return (selectOnly(
+      identitiesTable,
+    )..addColumns([count])).map((row) => row.read(count)!).watchSingle().future;
+  }
+
+  StreamFuture<Identity?> getOrNull(int id) => (select(
+    identitiesTable,
+  )..where((tbl) => tbl.id.equals(id))).watchSingleOrNull().future;
+
+  StreamFuture<Identity> get(int id) =>
+      getOrNull(id).stream.map((e) => e!).future;
+
+  SimpleSelectStatement<IdentitiesTable, Identity> _queryExpression({
+    String? nameRegex,
+    String? hostRegex,
+    int? limit,
+    int? offset,
+  }) {
+    final selectable = select(identitiesTable)
+      ..orderBy([
+        (t) => OrderingTerm(expression: t.host),
+        (t) => OrderingTerm(expression: t.username),
+      ]);
+    if (nameRegex != null) {
+      selectable.where(
+        (tbl) => tbl.username.regexp(nameRegex, caseSensitive: false),
+      );
+    }
+    if (hostRegex != null) {
+      selectable.where(
+        (tbl) => tbl.host.regexp(hostRegex, caseSensitive: false),
+      );
+    }
+    assert(
+      offset == null || limit != null,
+      'Cannot specify offset without limit!',
+    );
+    if (limit != null) {
+      selectable.limit(limit, offset: offset);
+    }
+    return selectable;
+  }
+
+  StreamFuture<List<Identity>> page({
+    required int page,
+    int? limit,
+    String? nameRegex,
+    String? hostRegex,
+  }) {
+    limit ??= 80;
+    int offset = (max(1, page) - 1) * limit;
+    return _queryExpression(
+      nameRegex: nameRegex,
+      hostRegex: hostRegex,
+      limit: limit,
+      offset: offset,
+    ).watch().future;
+  }
+
+  StreamFuture<List<Identity>> all({String? nameRegex, String? hostRegex}) {
+    return _queryExpression(
+      nameRegex: nameRegex,
+      hostRegex: hostRegex,
+    ).watch().future;
+  }
+
+  Future<Identity> add(IdentityRequest item) async =>
+      into(identitiesTable).insertReturning(item.toCompanion());
+
+  Future<void> addAll(List<IdentityRequest> items) async => batch(
+    (batch) => batch.insertAll(
+      identitiesTable,
+      items.map((item) => item.toCompanion()),
+    ),
+  );
+
+  Future<void> remove(Identity item) async =>
+      (delete(identitiesTable)..where((tbl) => tbl.id.equals(item.id))).go();
+
+  Future<void> removeAll(List<Identity> items) async => (delete(
+    identitiesTable,
+  )..where((tbl) => tbl.id.isIn(items.map((e) => e.id)))).go();
+
+  Future<void> replace(Identity item) async => (update(
+    identitiesTable,
+  )..where((tbl) => tbl.id.equals(item.id))).write(item.toInsertable());
+}
+
+extension IdentityRequestCompanion on IdentityRequest {
+  IdentityCompanion toCompanion() => IdentityCompanion(
+    host: Value(normalizeHostUrl(host)),
+    username: Value(username),
+    headers: Value(headers),
+  );
+}

--- a/lib/identity/data/client.drift.dart
+++ b/lib/identity/data/client.drift.dart
@@ -1,0 +1,434 @@
+// dart format width=80
+// ignore_for_file: type=lint
+import 'package:drift/drift.dart' as i0;
+import 'package:drift/src/runtime/api/runtime_api.dart' as i1;
+import 'package:e1547/identity/data/client.drift.dart' as i2;
+import 'package:drift/internal/modular.dart' as i3;
+import 'package:e1547/identity/data/identity.dart' as i4;
+import 'package:e1547/identity/data/client.dart' as i5;
+import 'package:e1547/shared/data/sql.dart' as i6;
+
+typedef $$IdentitiesTableTableCreateCompanionBuilder =
+    i2.IdentityCompanion Function({
+      i0.Value<int> id,
+      required String host,
+      required String? username,
+      i0.Value<Map<String, String>?> headers,
+    });
+typedef $$IdentitiesTableTableUpdateCompanionBuilder =
+    i2.IdentityCompanion Function({
+      i0.Value<int> id,
+      i0.Value<String> host,
+      i0.Value<String?> username,
+      i0.Value<Map<String, String>?> headers,
+    });
+
+class $$IdentitiesTableTableFilterComposer
+    extends i0.Composer<i0.GeneratedDatabase, i2.$IdentitiesTableTable> {
+  $$IdentitiesTableTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  i0.ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => i0.ColumnFilters(column),
+  );
+
+  i0.ColumnFilters<String> get host => $composableBuilder(
+    column: $table.host,
+    builder: (column) => i0.ColumnFilters(column),
+  );
+
+  i0.ColumnWithTypeConverterFilters<String?, String, String> get username =>
+      $composableBuilder(
+        column: $table.username,
+        builder: (column) => i0.ColumnWithTypeConverterFilters(column),
+      );
+
+  i0.ColumnWithTypeConverterFilters<
+    Map<String, String>?,
+    Map<String, String>,
+    String
+  >
+  get headers => $composableBuilder(
+    column: $table.headers,
+    builder: (column) => i0.ColumnWithTypeConverterFilters(column),
+  );
+}
+
+class $$IdentitiesTableTableOrderingComposer
+    extends i0.Composer<i0.GeneratedDatabase, i2.$IdentitiesTableTable> {
+  $$IdentitiesTableTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  i0.ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => i0.ColumnOrderings(column),
+  );
+
+  i0.ColumnOrderings<String> get host => $composableBuilder(
+    column: $table.host,
+    builder: (column) => i0.ColumnOrderings(column),
+  );
+
+  i0.ColumnOrderings<String> get username => $composableBuilder(
+    column: $table.username,
+    builder: (column) => i0.ColumnOrderings(column),
+  );
+
+  i0.ColumnOrderings<String> get headers => $composableBuilder(
+    column: $table.headers,
+    builder: (column) => i0.ColumnOrderings(column),
+  );
+}
+
+class $$IdentitiesTableTableAnnotationComposer
+    extends i0.Composer<i0.GeneratedDatabase, i2.$IdentitiesTableTable> {
+  $$IdentitiesTableTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  i0.GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  i0.GeneratedColumn<String> get host =>
+      $composableBuilder(column: $table.host, builder: (column) => column);
+
+  i0.GeneratedColumnWithTypeConverter<String?, String> get username =>
+      $composableBuilder(column: $table.username, builder: (column) => column);
+
+  i0.GeneratedColumnWithTypeConverter<Map<String, String>?, String>
+  get headers =>
+      $composableBuilder(column: $table.headers, builder: (column) => column);
+}
+
+class $$IdentitiesTableTableTableManager
+    extends
+        i0.RootTableManager<
+          i0.GeneratedDatabase,
+          i2.$IdentitiesTableTable,
+          i4.Identity,
+          i2.$$IdentitiesTableTableFilterComposer,
+          i2.$$IdentitiesTableTableOrderingComposer,
+          i2.$$IdentitiesTableTableAnnotationComposer,
+          $$IdentitiesTableTableCreateCompanionBuilder,
+          $$IdentitiesTableTableUpdateCompanionBuilder,
+          (
+            i4.Identity,
+            i0.BaseReferences<
+              i0.GeneratedDatabase,
+              i2.$IdentitiesTableTable,
+              i4.Identity
+            >,
+          ),
+          i4.Identity,
+          i0.PrefetchHooks Function()
+        > {
+  $$IdentitiesTableTableTableManager(
+    i0.GeneratedDatabase db,
+    i2.$IdentitiesTableTable table,
+  ) : super(
+        i0.TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              i2.$$IdentitiesTableTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              i2.$$IdentitiesTableTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () => i2
+              .$$IdentitiesTableTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                i0.Value<int> id = const i0.Value.absent(),
+                i0.Value<String> host = const i0.Value.absent(),
+                i0.Value<String?> username = const i0.Value.absent(),
+                i0.Value<Map<String, String>?> headers =
+                    const i0.Value.absent(),
+              }) => i2.IdentityCompanion(
+                id: id,
+                host: host,
+                username: username,
+                headers: headers,
+              ),
+          createCompanionCallback:
+              ({
+                i0.Value<int> id = const i0.Value.absent(),
+                required String host,
+                required String? username,
+                i0.Value<Map<String, String>?> headers =
+                    const i0.Value.absent(),
+              }) => i2.IdentityCompanion.insert(
+                id: id,
+                host: host,
+                username: username,
+                headers: headers,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$IdentitiesTableTableProcessedTableManager =
+    i0.ProcessedTableManager<
+      i0.GeneratedDatabase,
+      i2.$IdentitiesTableTable,
+      i4.Identity,
+      i2.$$IdentitiesTableTableFilterComposer,
+      i2.$$IdentitiesTableTableOrderingComposer,
+      i2.$$IdentitiesTableTableAnnotationComposer,
+      $$IdentitiesTableTableCreateCompanionBuilder,
+      $$IdentitiesTableTableUpdateCompanionBuilder,
+      (
+        i4.Identity,
+        i0.BaseReferences<
+          i0.GeneratedDatabase,
+          i2.$IdentitiesTableTable,
+          i4.Identity
+        >,
+      ),
+      i4.Identity,
+      i0.PrefetchHooks Function()
+    >;
+mixin $IdentityClientMixin on i0.DatabaseAccessor<i1.GeneratedDatabase> {
+  i2.$IdentitiesTableTable get identitiesTable => i3.ReadDatabaseContainer(
+    attachedDatabase,
+  ).resultSet<i2.$IdentitiesTableTable>('identities_table');
+}
+
+class $IdentitiesTableTable extends i5.IdentitiesTable
+    with i0.TableInfo<$IdentitiesTableTable, i4.Identity> {
+  @override
+  final i0.GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $IdentitiesTableTable(this.attachedDatabase, [this._alias]);
+  static const i0.VerificationMeta _idMeta = const i0.VerificationMeta('id');
+  @override
+  late final i0.GeneratedColumn<int> id = i0.GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: i0.DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: i0.GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const i0.VerificationMeta _hostMeta = const i0.VerificationMeta(
+    'host',
+  );
+  @override
+  late final i0.GeneratedColumn<String> host = i0.GeneratedColumn<String>(
+    'host',
+    aliasedName,
+    false,
+    type: i0.DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  late final i0.GeneratedColumnWithTypeConverter<String?, String> username =
+      i0.GeneratedColumn<String>(
+        'username',
+        aliasedName,
+        false,
+        type: i0.DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<String?>(i2.$IdentitiesTableTable.$converterusername);
+  @override
+  late final i0.GeneratedColumnWithTypeConverter<Map<String, String>?, String>
+  headers =
+      i0.GeneratedColumn<String>(
+        'headers',
+        aliasedName,
+        true,
+        type: i0.DriftSqlType.string,
+        requiredDuringInsert: false,
+      ).withConverter<Map<String, String>?>(
+        i2.$IdentitiesTableTable.$converterheadersn,
+      );
+  @override
+  List<i0.GeneratedColumn> get $columns => [id, host, username, headers];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'identities_table';
+  @override
+  i0.VerificationContext validateIntegrity(
+    i0.Insertable<i4.Identity> instance, {
+    bool isInserting = false,
+  }) {
+    final context = i0.VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('host')) {
+      context.handle(
+        _hostMeta,
+        host.isAcceptableOrUnknown(data['host']!, _hostMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_hostMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<i0.GeneratedColumn> get $primaryKey => {id};
+  @override
+  List<Set<i0.GeneratedColumn>> get uniqueKeys => [
+    {host, username},
+  ];
+  @override
+  i4.Identity map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return i4.Identity(
+      id: attachedDatabase.typeMapping.read(
+        i0.DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      host: attachedDatabase.typeMapping.read(
+        i0.DriftSqlType.string,
+        data['${effectivePrefix}host'],
+      )!,
+      username: i2.$IdentitiesTableTable.$converterusername.fromSql(
+        attachedDatabase.typeMapping.read(
+          i0.DriftSqlType.string,
+          data['${effectivePrefix}username'],
+        )!,
+      ),
+      headers: i2.$IdentitiesTableTable.$converterheadersn.fromSql(
+        attachedDatabase.typeMapping.read(
+          i0.DriftSqlType.string,
+          data['${effectivePrefix}headers'],
+        ),
+      ),
+    );
+  }
+
+  @override
+  $IdentitiesTableTable createAlias(String alias) {
+    return $IdentitiesTableTable(attachedDatabase, alias);
+  }
+
+  static i0.TypeConverter<String?, String> $converterusername =
+      const i5.NullToEmptyStringSqlConverter();
+  static i0.TypeConverter<Map<String, String>, String> $converterheaders =
+      i6.JsonSqlConverter.map<String>();
+  static i0.TypeConverter<Map<String, String>?, String?> $converterheadersn =
+      i0.NullAwareTypeConverter.wrap($converterheaders);
+}
+
+class IdentityCompanion extends i0.UpdateCompanion<i4.Identity> {
+  final i0.Value<int> id;
+  final i0.Value<String> host;
+  final i0.Value<String?> username;
+  final i0.Value<Map<String, String>?> headers;
+  const IdentityCompanion({
+    this.id = const i0.Value.absent(),
+    this.host = const i0.Value.absent(),
+    this.username = const i0.Value.absent(),
+    this.headers = const i0.Value.absent(),
+  });
+  IdentityCompanion.insert({
+    this.id = const i0.Value.absent(),
+    required String host,
+    required String? username,
+    this.headers = const i0.Value.absent(),
+  }) : host = i0.Value(host),
+       username = i0.Value(username);
+  static i0.Insertable<i4.Identity> custom({
+    i0.Expression<int>? id,
+    i0.Expression<String>? host,
+    i0.Expression<String>? username,
+    i0.Expression<String>? headers,
+  }) {
+    return i0.RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (host != null) 'host': host,
+      if (username != null) 'username': username,
+      if (headers != null) 'headers': headers,
+    });
+  }
+
+  i2.IdentityCompanion copyWith({
+    i0.Value<int>? id,
+    i0.Value<String>? host,
+    i0.Value<String?>? username,
+    i0.Value<Map<String, String>?>? headers,
+  }) {
+    return i2.IdentityCompanion(
+      id: id ?? this.id,
+      host: host ?? this.host,
+      username: username ?? this.username,
+      headers: headers ?? this.headers,
+    );
+  }
+
+  @override
+  Map<String, i0.Expression> toColumns(bool nullToAbsent) {
+    final map = <String, i0.Expression>{};
+    if (id.present) {
+      map['id'] = i0.Variable<int>(id.value);
+    }
+    if (host.present) {
+      map['host'] = i0.Variable<String>(host.value);
+    }
+    if (username.present) {
+      map['username'] = i0.Variable<String>(
+        i2.$IdentitiesTableTable.$converterusername.toSql(username.value),
+      );
+    }
+    if (headers.present) {
+      map['headers'] = i0.Variable<String>(
+        i2.$IdentitiesTableTable.$converterheadersn.toSql(headers.value),
+      );
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('IdentityCompanion(')
+          ..write('id: $id, ')
+          ..write('host: $host, ')
+          ..write('username: $username, ')
+          ..write('headers: $headers')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class _$IdentityInsertable implements i0.Insertable<i4.Identity> {
+  i4.Identity _object;
+  _$IdentityInsertable(this._object);
+  @override
+  Map<String, i0.Expression> toColumns(bool nullToAbsent) {
+    return i2.IdentityCompanion(
+      id: i0.Value(_object.id),
+      host: i0.Value(_object.host),
+      username: i0.Value(_object.username),
+      headers: i0.Value(_object.headers),
+    ).toColumns(false);
+  }
+}
+
+extension IdentityToInsertable on i4.Identity {
+  _$IdentityInsertable toInsertable() {
+    return _$IdentityInsertable(this);
+  }
+}

--- a/lib/identity/data/data.dart
+++ b/lib/identity/data/data.dart
@@ -1,1 +1,5 @@
+export 'actions.dart';
+export 'client.dart';
+export 'client.drift.dart';
 export 'identity.dart';
+export 'repo.dart';

--- a/lib/identity/data/repo.dart
+++ b/lib/identity/data/repo.dart
@@ -1,0 +1,40 @@
+import 'package:e1547/identity/data/client.dart';
+import 'package:e1547/identity/data/identity.dart';
+import 'package:e1547/stream/stream.dart';
+
+class IdentityRepo {
+  IdentityRepo({required this.client});
+
+  final IdentityClient client;
+
+  StreamFuture<int> length() => client.length();
+
+  StreamFuture<Identity?> getOrNull(int id) => client.getOrNull(id);
+
+  StreamFuture<Identity> get(int id) => client.get(id);
+
+  StreamFuture<List<Identity>> page({
+    required int page,
+    int? limit,
+    String? nameRegex,
+    String? hostRegex,
+  }) => client.page(
+    page: page,
+    limit: limit,
+    nameRegex: nameRegex,
+    hostRegex: hostRegex,
+  );
+
+  StreamFuture<List<Identity>> all({String? nameRegex, String? hostRegex}) =>
+      client.all(nameRegex: nameRegex, hostRegex: hostRegex);
+
+  Future<Identity> add(IdentityRequest item) => client.add(item);
+
+  Future<void> addAll(List<IdentityRequest> items) => client.addAll(items);
+
+  Future<void> remove(Identity item) => client.remove(item);
+
+  Future<void> removeAll(List<Identity> items) => client.removeAll(items);
+
+  Future<void> replace(Identity item) => client.replace(item);
+}

--- a/lib/shared/data/data.dart
+++ b/lib/shared/data/data.dart
@@ -5,4 +5,5 @@ export 'package.dart';
 export 'pagination.dart';
 export 'persona.dart';
 export 'rails.dart';
+export 'sql.dart';
 export 'text.dart';

--- a/lib/shared/data/sql.dart
+++ b/lib/shared/data/sql.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
+
+@optionalTypeArgs
+class JsonSqlConverter<T> extends TypeConverter<T, String> {
+  const JsonSqlConverter({this.decode});
+
+  static JsonSqlConverter<List<R>> list<R>() => JsonSqlConverter<List<R>>(
+    decode: (value) => (value as List<dynamic>).cast<R>(),
+  );
+
+  static JsonSqlConverter<Map<String, R>> map<R>() =>
+      JsonSqlConverter<Map<String, R>>(
+        decode: (value) => (value as Map<String, dynamic>)
+            .map((key, dynamicValue) => MapEntry(key, dynamicValue as R))
+            .cast(),
+      );
+
+  final T Function(dynamic value)? decode;
+
+  @override
+  T fromSql(String fromDb) {
+    final dynamic value = json.decode(fromDb);
+    if (decode != null) {
+      return decode!(value);
+    }
+    return value as T;
+  }
+
+  @override
+  String toSql(T value) => json.encode(value);
+}

--- a/lib/traits/data/client.dart
+++ b/lib/traits/data/client.dart
@@ -1,0 +1,55 @@
+import 'package:drift/drift.dart';
+import 'package:e1547/identity/data/client.dart';
+import 'package:e1547/shared/shared.dart';
+import 'package:e1547/stream/stream.dart';
+import 'package:e1547/traits/data/client.drift.dart';
+import 'package:e1547/traits/data/traits.dart';
+
+@UseRowClass(Traits, generateInsertable: true)
+class TraitsTable extends Table {
+  IntColumn get id => integer().references(
+    IdentitiesTable,
+    #id,
+    onUpdate: KeyAction.cascade,
+    onDelete: KeyAction.cascade,
+  )();
+  IntColumn get userId => integer().nullable()();
+  TextColumn get denylist => text().map(JsonSqlConverter.list<String>())();
+  TextColumn get homeTags => text()();
+  TextColumn get avatar => text().nullable()();
+  IntColumn get perPage => integer().nullable()();
+
+  @override
+  Set<Column<Object>>? get primaryKey => {id};
+}
+
+@DriftAccessor(tables: [IdentitiesTable, TraitsTable])
+class TraitsClient extends DatabaseAccessor<GeneratedDatabase>
+    with $TraitsClientMixin {
+  TraitsClient(super.db);
+
+  StreamFuture<Traits?> getOrNull(int id) {
+    return (select(
+      traitsTable,
+    )..where((t) => t.id.equals(id))).watchSingleOrNull().future;
+  }
+
+  StreamFuture<Traits> get(int id) =>
+      getOrNull(id).stream.map((event) => event!).future;
+
+  Future<Traits> add(TraitsRequest value) {
+    return into(traitsTable).insertReturning(
+      TraitsCompanion(
+        id: Value(value.identity),
+        denylist: Value(value.denylist),
+        homeTags: Value(value.homeTags),
+      ),
+    );
+  }
+
+  Future<void> remove(Traits value) =>
+      (delete(traitsTable)..where((t) => t.id.equals(value.id))).go();
+
+  Future<void> replace(Traits value) =>
+      update(traitsTable).replace(value.toInsertable());
+}

--- a/lib/traits/data/client.drift.dart
+++ b/lib/traits/data/client.drift.dart
@@ -1,0 +1,676 @@
+// dart format width=80
+// ignore_for_file: type=lint
+import 'package:drift/drift.dart' as i0;
+import 'package:drift/src/runtime/api/runtime_api.dart' as i1;
+import 'package:e1547/identity/data/client.drift.dart' as i2;
+import 'package:drift/internal/modular.dart' as i3;
+import 'package:e1547/traits/data/client.drift.dart' as i4;
+import 'package:e1547/traits/data/traits.dart' as i5;
+import 'package:e1547/traits/data/client.dart' as i6;
+import 'package:e1547/shared/data/sql.dart' as i7;
+
+typedef $$TraitsTableTableCreateCompanionBuilder =
+    i4.TraitsCompanion Function({
+      i0.Value<int> id,
+      i0.Value<int?> userId,
+      required List<String> denylist,
+      required String homeTags,
+      i0.Value<String?> avatar,
+      i0.Value<int?> perPage,
+    });
+typedef $$TraitsTableTableUpdateCompanionBuilder =
+    i4.TraitsCompanion Function({
+      i0.Value<int> id,
+      i0.Value<int?> userId,
+      i0.Value<List<String>> denylist,
+      i0.Value<String> homeTags,
+      i0.Value<String?> avatar,
+      i0.Value<int?> perPage,
+    });
+
+final class $$TraitsTableTableReferences
+    extends
+        i0.BaseReferences<
+          i0.GeneratedDatabase,
+          i4.$TraitsTableTable,
+          i5.Traits
+        > {
+  $$TraitsTableTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static i2.$IdentitiesTableTable _idTable(i0.GeneratedDatabase db) =>
+      i3.ReadDatabaseContainer(db)
+          .resultSet<i2.$IdentitiesTableTable>('identities_table')
+          .createAlias(
+            i0.$_aliasNameGenerator(
+              i3.ReadDatabaseContainer(
+                db,
+              ).resultSet<i4.$TraitsTableTable>('traits_table').id,
+              i3.ReadDatabaseContainer(
+                db,
+              ).resultSet<i2.$IdentitiesTableTable>('identities_table').id,
+            ),
+          );
+
+  i2.$$IdentitiesTableTableProcessedTableManager get id {
+    final $_column = $_itemColumn<int>('id')!;
+
+    final manager = i2
+        .$$IdentitiesTableTableTableManager(
+          $_db,
+          i3.ReadDatabaseContainer(
+            $_db,
+          ).resultSet<i2.$IdentitiesTableTable>('identities_table'),
+        )
+        .filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_idTable($_db));
+    if (item == null) return manager;
+    return i0.ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$TraitsTableTableFilterComposer
+    extends i0.Composer<i0.GeneratedDatabase, i4.$TraitsTableTable> {
+  $$TraitsTableTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  i0.ColumnFilters<int> get userId => $composableBuilder(
+    column: $table.userId,
+    builder: (column) => i0.ColumnFilters(column),
+  );
+
+  i0.ColumnWithTypeConverterFilters<List<String>, List<String>, String>
+  get denylist => $composableBuilder(
+    column: $table.denylist,
+    builder: (column) => i0.ColumnWithTypeConverterFilters(column),
+  );
+
+  i0.ColumnFilters<String> get homeTags => $composableBuilder(
+    column: $table.homeTags,
+    builder: (column) => i0.ColumnFilters(column),
+  );
+
+  i0.ColumnFilters<String> get avatar => $composableBuilder(
+    column: $table.avatar,
+    builder: (column) => i0.ColumnFilters(column),
+  );
+
+  i0.ColumnFilters<int> get perPage => $composableBuilder(
+    column: $table.perPage,
+    builder: (column) => i0.ColumnFilters(column),
+  );
+
+  i2.$$IdentitiesTableTableFilterComposer get id {
+    final i2.$$IdentitiesTableTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: i3.ReadDatabaseContainer(
+        $db,
+      ).resultSet<i2.$IdentitiesTableTable>('identities_table'),
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => i2.$$IdentitiesTableTableFilterComposer(
+            $db: $db,
+            $table: i3.ReadDatabaseContainer(
+              $db,
+            ).resultSet<i2.$IdentitiesTableTable>('identities_table'),
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$TraitsTableTableOrderingComposer
+    extends i0.Composer<i0.GeneratedDatabase, i4.$TraitsTableTable> {
+  $$TraitsTableTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  i0.ColumnOrderings<int> get userId => $composableBuilder(
+    column: $table.userId,
+    builder: (column) => i0.ColumnOrderings(column),
+  );
+
+  i0.ColumnOrderings<String> get denylist => $composableBuilder(
+    column: $table.denylist,
+    builder: (column) => i0.ColumnOrderings(column),
+  );
+
+  i0.ColumnOrderings<String> get homeTags => $composableBuilder(
+    column: $table.homeTags,
+    builder: (column) => i0.ColumnOrderings(column),
+  );
+
+  i0.ColumnOrderings<String> get avatar => $composableBuilder(
+    column: $table.avatar,
+    builder: (column) => i0.ColumnOrderings(column),
+  );
+
+  i0.ColumnOrderings<int> get perPage => $composableBuilder(
+    column: $table.perPage,
+    builder: (column) => i0.ColumnOrderings(column),
+  );
+
+  i2.$$IdentitiesTableTableOrderingComposer get id {
+    final i2.$$IdentitiesTableTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: i3.ReadDatabaseContainer(
+        $db,
+      ).resultSet<i2.$IdentitiesTableTable>('identities_table'),
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => i2.$$IdentitiesTableTableOrderingComposer(
+            $db: $db,
+            $table: i3.ReadDatabaseContainer(
+              $db,
+            ).resultSet<i2.$IdentitiesTableTable>('identities_table'),
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$TraitsTableTableAnnotationComposer
+    extends i0.Composer<i0.GeneratedDatabase, i4.$TraitsTableTable> {
+  $$TraitsTableTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  i0.GeneratedColumn<int> get userId =>
+      $composableBuilder(column: $table.userId, builder: (column) => column);
+
+  i0.GeneratedColumnWithTypeConverter<List<String>, String> get denylist =>
+      $composableBuilder(column: $table.denylist, builder: (column) => column);
+
+  i0.GeneratedColumn<String> get homeTags =>
+      $composableBuilder(column: $table.homeTags, builder: (column) => column);
+
+  i0.GeneratedColumn<String> get avatar =>
+      $composableBuilder(column: $table.avatar, builder: (column) => column);
+
+  i0.GeneratedColumn<int> get perPage =>
+      $composableBuilder(column: $table.perPage, builder: (column) => column);
+
+  i2.$$IdentitiesTableTableAnnotationComposer get id {
+    final i2.$$IdentitiesTableTableAnnotationComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: i3.ReadDatabaseContainer(
+            $db,
+          ).resultSet<i2.$IdentitiesTableTable>('identities_table'),
+          getReferencedColumn: (t) => t.id,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => i2.$$IdentitiesTableTableAnnotationComposer(
+                $db: $db,
+                $table: i3.ReadDatabaseContainer(
+                  $db,
+                ).resultSet<i2.$IdentitiesTableTable>('identities_table'),
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return composer;
+  }
+}
+
+class $$TraitsTableTableTableManager
+    extends
+        i0.RootTableManager<
+          i0.GeneratedDatabase,
+          i4.$TraitsTableTable,
+          i5.Traits,
+          i4.$$TraitsTableTableFilterComposer,
+          i4.$$TraitsTableTableOrderingComposer,
+          i4.$$TraitsTableTableAnnotationComposer,
+          $$TraitsTableTableCreateCompanionBuilder,
+          $$TraitsTableTableUpdateCompanionBuilder,
+          (i5.Traits, i4.$$TraitsTableTableReferences),
+          i5.Traits,
+          i0.PrefetchHooks Function({bool id})
+        > {
+  $$TraitsTableTableTableManager(
+    i0.GeneratedDatabase db,
+    i4.$TraitsTableTable table,
+  ) : super(
+        i0.TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              i4.$$TraitsTableTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              i4.$$TraitsTableTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              i4.$$TraitsTableTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                i0.Value<int> id = const i0.Value.absent(),
+                i0.Value<int?> userId = const i0.Value.absent(),
+                i0.Value<List<String>> denylist = const i0.Value.absent(),
+                i0.Value<String> homeTags = const i0.Value.absent(),
+                i0.Value<String?> avatar = const i0.Value.absent(),
+                i0.Value<int?> perPage = const i0.Value.absent(),
+              }) => i4.TraitsCompanion(
+                id: id,
+                userId: userId,
+                denylist: denylist,
+                homeTags: homeTags,
+                avatar: avatar,
+                perPage: perPage,
+              ),
+          createCompanionCallback:
+              ({
+                i0.Value<int> id = const i0.Value.absent(),
+                i0.Value<int?> userId = const i0.Value.absent(),
+                required List<String> denylist,
+                required String homeTags,
+                i0.Value<String?> avatar = const i0.Value.absent(),
+                i0.Value<int?> perPage = const i0.Value.absent(),
+              }) => i4.TraitsCompanion.insert(
+                id: id,
+                userId: userId,
+                denylist: denylist,
+                homeTags: homeTags,
+                avatar: avatar,
+                perPage: perPage,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  i4.$$TraitsTableTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({id = false}) {
+            return i0.PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends i0.TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (id) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.id,
+                                referencedTable: i4.$$TraitsTableTableReferences
+                                    ._idTable(db),
+                                referencedColumn: i4
+                                    .$$TraitsTableTableReferences
+                                    ._idTable(db)
+                                    .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$TraitsTableTableProcessedTableManager =
+    i0.ProcessedTableManager<
+      i0.GeneratedDatabase,
+      i4.$TraitsTableTable,
+      i5.Traits,
+      i4.$$TraitsTableTableFilterComposer,
+      i4.$$TraitsTableTableOrderingComposer,
+      i4.$$TraitsTableTableAnnotationComposer,
+      $$TraitsTableTableCreateCompanionBuilder,
+      $$TraitsTableTableUpdateCompanionBuilder,
+      (i5.Traits, i4.$$TraitsTableTableReferences),
+      i5.Traits,
+      i0.PrefetchHooks Function({bool id})
+    >;
+mixin $TraitsClientMixin on i0.DatabaseAccessor<i1.GeneratedDatabase> {
+  i2.$IdentitiesTableTable get identitiesTable => i3.ReadDatabaseContainer(
+    attachedDatabase,
+  ).resultSet<i2.$IdentitiesTableTable>('identities_table');
+  i4.$TraitsTableTable get traitsTable => i3.ReadDatabaseContainer(
+    attachedDatabase,
+  ).resultSet<i4.$TraitsTableTable>('traits_table');
+}
+
+class $TraitsTableTable extends i6.TraitsTable
+    with i0.TableInfo<$TraitsTableTable, i5.Traits> {
+  @override
+  final i0.GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $TraitsTableTable(this.attachedDatabase, [this._alias]);
+  static const i0.VerificationMeta _idMeta = const i0.VerificationMeta('id');
+  @override
+  late final i0.GeneratedColumn<int> id = i0.GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    type: i0.DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: i0.GeneratedColumn.constraintIsAlways(
+      'REFERENCES identities_table (id) ON UPDATE CASCADE ON DELETE CASCADE',
+    ),
+  );
+  static const i0.VerificationMeta _userIdMeta = const i0.VerificationMeta(
+    'userId',
+  );
+  @override
+  late final i0.GeneratedColumn<int> userId = i0.GeneratedColumn<int>(
+    'user_id',
+    aliasedName,
+    true,
+    type: i0.DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  @override
+  late final i0.GeneratedColumnWithTypeConverter<List<String>, String>
+  denylist = i0.GeneratedColumn<String>(
+    'denylist',
+    aliasedName,
+    false,
+    type: i0.DriftSqlType.string,
+    requiredDuringInsert: true,
+  ).withConverter<List<String>>(i4.$TraitsTableTable.$converterdenylist);
+  static const i0.VerificationMeta _homeTagsMeta = const i0.VerificationMeta(
+    'homeTags',
+  );
+  @override
+  late final i0.GeneratedColumn<String> homeTags = i0.GeneratedColumn<String>(
+    'home_tags',
+    aliasedName,
+    false,
+    type: i0.DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const i0.VerificationMeta _avatarMeta = const i0.VerificationMeta(
+    'avatar',
+  );
+  @override
+  late final i0.GeneratedColumn<String> avatar = i0.GeneratedColumn<String>(
+    'avatar',
+    aliasedName,
+    true,
+    type: i0.DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const i0.VerificationMeta _perPageMeta = const i0.VerificationMeta(
+    'perPage',
+  );
+  @override
+  late final i0.GeneratedColumn<int> perPage = i0.GeneratedColumn<int>(
+    'per_page',
+    aliasedName,
+    true,
+    type: i0.DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<i0.GeneratedColumn> get $columns => [
+    id,
+    userId,
+    denylist,
+    homeTags,
+    avatar,
+    perPage,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'traits_table';
+  @override
+  i0.VerificationContext validateIntegrity(
+    i0.Insertable<i5.Traits> instance, {
+    bool isInserting = false,
+  }) {
+    final context = i0.VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('user_id')) {
+      context.handle(
+        _userIdMeta,
+        userId.isAcceptableOrUnknown(data['user_id']!, _userIdMeta),
+      );
+    }
+    if (data.containsKey('home_tags')) {
+      context.handle(
+        _homeTagsMeta,
+        homeTags.isAcceptableOrUnknown(data['home_tags']!, _homeTagsMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_homeTagsMeta);
+    }
+    if (data.containsKey('avatar')) {
+      context.handle(
+        _avatarMeta,
+        avatar.isAcceptableOrUnknown(data['avatar']!, _avatarMeta),
+      );
+    }
+    if (data.containsKey('per_page')) {
+      context.handle(
+        _perPageMeta,
+        perPage.isAcceptableOrUnknown(data['per_page']!, _perPageMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<i0.GeneratedColumn> get $primaryKey => {id};
+  @override
+  i5.Traits map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return i5.Traits(
+      id: attachedDatabase.typeMapping.read(
+        i0.DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      userId: attachedDatabase.typeMapping.read(
+        i0.DriftSqlType.int,
+        data['${effectivePrefix}user_id'],
+      ),
+      denylist: i4.$TraitsTableTable.$converterdenylist.fromSql(
+        attachedDatabase.typeMapping.read(
+          i0.DriftSqlType.string,
+          data['${effectivePrefix}denylist'],
+        )!,
+      ),
+      homeTags: attachedDatabase.typeMapping.read(
+        i0.DriftSqlType.string,
+        data['${effectivePrefix}home_tags'],
+      )!,
+      avatar: attachedDatabase.typeMapping.read(
+        i0.DriftSqlType.string,
+        data['${effectivePrefix}avatar'],
+      ),
+      perPage: attachedDatabase.typeMapping.read(
+        i0.DriftSqlType.int,
+        data['${effectivePrefix}per_page'],
+      ),
+    );
+  }
+
+  @override
+  $TraitsTableTable createAlias(String alias) {
+    return $TraitsTableTable(attachedDatabase, alias);
+  }
+
+  static i0.TypeConverter<List<String>, String> $converterdenylist =
+      i7.JsonSqlConverter.list<String>();
+}
+
+class TraitsCompanion extends i0.UpdateCompanion<i5.Traits> {
+  final i0.Value<int> id;
+  final i0.Value<int?> userId;
+  final i0.Value<List<String>> denylist;
+  final i0.Value<String> homeTags;
+  final i0.Value<String?> avatar;
+  final i0.Value<int?> perPage;
+  const TraitsCompanion({
+    this.id = const i0.Value.absent(),
+    this.userId = const i0.Value.absent(),
+    this.denylist = const i0.Value.absent(),
+    this.homeTags = const i0.Value.absent(),
+    this.avatar = const i0.Value.absent(),
+    this.perPage = const i0.Value.absent(),
+  });
+  TraitsCompanion.insert({
+    this.id = const i0.Value.absent(),
+    this.userId = const i0.Value.absent(),
+    required List<String> denylist,
+    required String homeTags,
+    this.avatar = const i0.Value.absent(),
+    this.perPage = const i0.Value.absent(),
+  }) : denylist = i0.Value(denylist),
+       homeTags = i0.Value(homeTags);
+  static i0.Insertable<i5.Traits> custom({
+    i0.Expression<int>? id,
+    i0.Expression<int>? userId,
+    i0.Expression<String>? denylist,
+    i0.Expression<String>? homeTags,
+    i0.Expression<String>? avatar,
+    i0.Expression<int>? perPage,
+  }) {
+    return i0.RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (userId != null) 'user_id': userId,
+      if (denylist != null) 'denylist': denylist,
+      if (homeTags != null) 'home_tags': homeTags,
+      if (avatar != null) 'avatar': avatar,
+      if (perPage != null) 'per_page': perPage,
+    });
+  }
+
+  i4.TraitsCompanion copyWith({
+    i0.Value<int>? id,
+    i0.Value<int?>? userId,
+    i0.Value<List<String>>? denylist,
+    i0.Value<String>? homeTags,
+    i0.Value<String?>? avatar,
+    i0.Value<int?>? perPage,
+  }) {
+    return i4.TraitsCompanion(
+      id: id ?? this.id,
+      userId: userId ?? this.userId,
+      denylist: denylist ?? this.denylist,
+      homeTags: homeTags ?? this.homeTags,
+      avatar: avatar ?? this.avatar,
+      perPage: perPage ?? this.perPage,
+    );
+  }
+
+  @override
+  Map<String, i0.Expression> toColumns(bool nullToAbsent) {
+    final map = <String, i0.Expression>{};
+    if (id.present) {
+      map['id'] = i0.Variable<int>(id.value);
+    }
+    if (userId.present) {
+      map['user_id'] = i0.Variable<int>(userId.value);
+    }
+    if (denylist.present) {
+      map['denylist'] = i0.Variable<String>(
+        i4.$TraitsTableTable.$converterdenylist.toSql(denylist.value),
+      );
+    }
+    if (homeTags.present) {
+      map['home_tags'] = i0.Variable<String>(homeTags.value);
+    }
+    if (avatar.present) {
+      map['avatar'] = i0.Variable<String>(avatar.value);
+    }
+    if (perPage.present) {
+      map['per_page'] = i0.Variable<int>(perPage.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('TraitsCompanion(')
+          ..write('id: $id, ')
+          ..write('userId: $userId, ')
+          ..write('denylist: $denylist, ')
+          ..write('homeTags: $homeTags, ')
+          ..write('avatar: $avatar, ')
+          ..write('perPage: $perPage')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class _$TraitsInsertable implements i0.Insertable<i5.Traits> {
+  i5.Traits _object;
+  _$TraitsInsertable(this._object);
+  @override
+  Map<String, i0.Expression> toColumns(bool nullToAbsent) {
+    return i4.TraitsCompanion(
+      id: i0.Value(_object.id),
+      userId: i0.Value(_object.userId),
+      denylist: i0.Value(_object.denylist),
+      homeTags: i0.Value(_object.homeTags),
+      avatar: i0.Value(_object.avatar),
+      perPage: i0.Value(_object.perPage),
+    ).toColumns(false);
+  }
+}
+
+extension TraitsToInsertable on i5.Traits {
+  _$TraitsInsertable toInsertable() {
+    return _$TraitsInsertable(this);
+  }
+}

--- a/lib/traits/data/data.dart
+++ b/lib/traits/data/data.dart
@@ -1,1 +1,4 @@
+export 'client.dart';
+export 'client.drift.dart';
+export 'repo.dart';
 export 'traits.dart';

--- a/lib/traits/data/repo.dart
+++ b/lib/traits/data/repo.dart
@@ -1,0 +1,19 @@
+import 'package:e1547/stream/stream.dart';
+import 'package:e1547/traits/data/client.dart';
+import 'package:e1547/traits/data/traits.dart';
+
+class TraitsRepo {
+  TraitsRepo({required this.client});
+
+  final TraitsClient client;
+
+  StreamFuture<Traits?> getOrNull(int id) => client.getOrNull(id);
+
+  StreamFuture<Traits> get(int id) => client.get(id);
+
+  Future<Traits> add(TraitsRequest value) => client.add(value);
+
+  Future<void> remove(Traits value) => client.remove(value);
+
+  Future<void> replace(Traits value) => client.replace(value);
+}


### PR DESCRIPTION
## Summary
- removed legacy interface package and relocated JsonSqlConverter to shared utilities
- updated identity and traits clients to use shared and stream modules
- refactored identity and traits repos to delegate to their clients without ChangeNotifier

## Testing
- `dart run build_runner build --delete-conflicting-outputs`
- `dart analyze`


------
https://chatgpt.com/codex/tasks/task_e_688fe3941de8832c886ca080c8010863